### PR TITLE
8343218: Add option to disable allocating interface and abstract classes in non-class metaspace

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -472,7 +472,7 @@ InstanceKlass* InstanceKlass::allocate_instance_klass(const ClassFileParser& par
   assert(loader_data != nullptr, "invariant");
 
   InstanceKlass* ik;
-  const bool use_class_space = parser.klass_needs_narrow_id();
+  const bool use_class_space = UseClassMetaspaceForAllClasses || parser.klass_needs_narrow_id();
 
   // Allocation
   if (parser.is_instance_ref_klass()) {

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,6 +182,6 @@ inline bool Klass::needs_narrow_id() const {
   // never instantiated classes out of class space lessens the class space pressure.
   // For more details, see JDK-8338526.
   // Note: don't call this function before access flags are initialized.
-  return !is_abstract() && !is_interface();
+  return UseClassMetaspaceForAllClasses || (!is_abstract() && !is_interface());
 }
 #endif // SHARE_OOPS_KLASS_INLINE_HPP

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2009,6 +2009,10 @@ const int ObjectAlignmentInBytes = 8;
   develop(uint, BinarySearchThreshold, 16,                                  \
           "Minimal number of elements in a sorted collection to prefer"     \
           "binary search over simple linear search." )                      \
+                                                                            \
+  product(bool, UseClassMetaspaceForAllClasses, false, DIAGNOSTIC,          \
+          "Use the class metaspace for all classes including "              \
+          "abstract and interface classes.")                                \
 
 // end of RUNTIME_FLAGS
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMetaspaceConstantImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMetaspaceConstantImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,7 @@ final class HotSpotMetaspaceConstantImpl implements HotSpotMetaspaceConstant, VM
     }
 
     private boolean canBeStoredInCompressibleMetaSpace() {
-        if (metaspaceObject instanceof HotSpotResolvedJavaType t && !t.isArray()) {
+        if (!HotSpotVMConfig.config().useClassMetaspaceForAllClasses && metaspaceObject instanceof HotSpotResolvedJavaType t && !t.isArray()) {
             // As of JDK-8338526, interface and abstract types are not stored
             // in compressible metaspace.
             return !t.isInterface() && !t.isAbstract();

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,8 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     final boolean useDeferredInitBarriers = getFlag("ReduceInitialCardMarks", Boolean.class);
 
     final boolean useCompressedOops = getFlag("UseCompressedOops", Boolean.class);
+
+    final boolean useClassMetaspaceForAllClasses = getFlag("UseClassMetaspaceForAllClasses", Boolean.class);
 
     final int objectAlignment = getFlag("ObjectAlignmentInBytes", Integer.class);
 


### PR DESCRIPTION
This backports [JDK-8343218](https://bugs.openjdk.org/browse/JDK-8343218) ahead of time in Corretto 25. As described in the issue, we have a reliability risk in compiler code when this optimization is enabled. Upstream plans to deal with it in 25.0.1/2, which is too late for us.

Therefore, I want to pull this backport ahead of time in Corretto 25 GA to give users the escape hatch to disable the optimization. We will also consider disabling the optimization by default, in a separate PR. This PR is left as verbatim backport of upstream change. There should be no behavior change with this flag, which avoids invalidating current JDK 25 testing.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `tier1`
 - [x] Linux AArch64 server fastdebug, `all`
 - [x] Linux x86_64 server fastdebug, `all`