### PR TITLE
Turn off interface/abstract class optimization for non-class metaspace allocation

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2010,7 +2010,7 @@ const int ObjectAlignmentInBytes = 8;
           "Minimal number of elements in a sorted collection to prefer"     \
           "binary search over simple linear search." )                      \
                                                                             \
-  product(bool, UseClassMetaspaceForAllClasses, false, DIAGNOSTIC,          \
+  product(bool, UseClassMetaspaceForAllClasses, true, DIAGNOSTIC,           \
           "Use the class metaspace for all classes including "              \
           "abstract and interface classes.")                                \
 


### PR DESCRIPTION
### Description and related issues

This flag flip follows https://github.com/corretto/corretto-25/pull/3 that introduced the flag. This PR puts Corretto 25 in more reliable configuratoin: all interface/abstract classes are allocated in class metaspace, like in all prior JDKs, exceptr for JDK 24.

### Motivation and context

In upstream, we have discovered this optimization violates some invariants the C2 compiler expects: namely, that every class is encodable. We know at least one C2 bug that was triggered by this, [JDK-8361211](https://bugs.openjdk.org/browse/JDK-8361211). Upstream has a plan to disable the flag and remove this optimization in both mainline and JDK 25u. It would likely be somewhere in 25.0.1/2 timeframe, which is too late for us.

This optimization was implemented in JDK 24, and thus it was not yet exposed widely. We expect that JDK 25 would see much more adoption from the get-go, and thus we want to eliminate the compiler misbehavior risk right in Corretto 25 GA.

When Corretto 25 catches up with 25.0.1/2, we expect to have a minor merge conflict that we would resolve in favor of upstream.

### How has this been tested?

The following tests pass:
  - [x] Linux AArch64 server fastdebug, `all`
  - [x] Linux x86_64 server fastdebug, `all`

### Platform information

No OS specificity.