### PR TITLE
ISSUE-10: Set OnSpinWaitInst to SB for Graviton 4

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -223,11 +223,11 @@ void VM_Version::initialize() {
     }
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInst)) {
-      const char *inst = "isb";
       if (model_is(0xd4f)) {
-        inst = "sb";
+        FLAG_SET_DEFAULT(OnSpinWaitInst, "sb");
+      } else {
+        FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
       }
-      FLAG_SET_DEFAULT(OnSpinWaitInst, inst);
     }
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -223,7 +223,11 @@ void VM_Version::initialize() {
     }
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInst)) {
-      FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
+      const char *inst = "isb";
+      if (model_is(0xd4f)) {
+        inst = "sb";
+      }
+      FLAG_SET_DEFAULT(OnSpinWaitInst, inst);
     }
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {


### PR DESCRIPTION
Graviton 4 is Neoverse-V2. SB-based spin pauses are less disruptive then ISB-based ones on Neoverse-V2.

This PR sets the default value for the `OnSpinWaitInst` flag to `"sb"` if the CPU model matches `0xd4f` (Neoverse-V2); otherwise, it remains `"isb"`.