### PR TITLE
Don't set OnSpinWaitInst to SB if VM_Version does not support it

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -223,7 +223,7 @@ void VM_Version::initialize() {
     }
 
     if (FLAG_IS_DEFAULT(OnSpinWaitInst)) {
-      if (model_is(0xd4f)) {
+      if (model_is(0xd4f) && VM_Version::supports_sb()) {
         FLAG_SET_DEFAULT(OnSpinWaitInst, "sb");
       } else {
         FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");


### PR DESCRIPTION
This is a fix of https://github.com/corretto/corretto-25/issues/16