### PR TITLE
Adjust check for "jfrconv" for full path

### DIFF
--- a/test/hotspot/jtreg/runtime/execstack/TestCheckJDK.java
+++ b/test/hotspot/jtreg/runtime/execstack/TestCheckJDK.java
@@ -37,6 +37,7 @@
 import jdk.test.lib.Asserts;
 import jdk.test.whitebox.WhiteBox;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,7 +49,8 @@ public class TestCheckJDK {
     static void checkExecStack(Path file) {
         String filename = file.toString();
         Path parent = file.getParent();
-        if ((parent.endsWith("bin") && !filename.endsWith(".diz") && !filename.equals("jfrconv")) || filename.endsWith(".so")) {
+        if ((parent.endsWith("bin") && !filename.endsWith(".diz") && !filename.endsWith(File.separator + "jfrconv")) 
+                || filename.endsWith(".so")) {
             if (!WB.checkLibSpecifiesNoexecstack(filename)) {
                 System.out.println("Library does not have the noexecstack bit set: " + filename);
                 testPassed = false;


### PR DESCRIPTION
The "filename" variable contains the whole path. Adjusted the check to look for the file separator and the file name ("jfrconv") at the end of the String.