### PR TITLE
Backport 8370572: Cgroups hierarchical memory limit is not honored after JDK-8322420

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -102,6 +102,17 @@
   log_trace(os, container)(log_string " is: %s", retval);                                 \
 }
 
+#define CONTAINER_READ_NUMERICAL_KEY_VALUE_CHECKED(controller, filename, key, log_string, retval) \
+{                                                                                     \
+  bool is_ok;                                                                         \
+  is_ok = controller->read_numerical_key_value(filename, key, &retval);               \
+  if (!is_ok) {                                                                       \
+    log_trace(os, container)(log_string " failed: %d", OSCONTAINER_ERROR);            \
+    return OSCONTAINER_ERROR;                                                         \
+  }                                                                                   \
+  log_trace(os, container)(log_string " is: " JULONG_FORMAT, retval);                 \
+}
+
 class CgroupController: public CHeapObj<mtInternal> {
   protected:
     char* _cgroup_path;

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -123,6 +123,12 @@ void CgroupV1Controller::set_subsystem_path(const char* cgroup_path) {
   }
 }
 
+jlong CgroupV1MemoryController::uses_mem_hierarchy() {
+  julong use_hierarchy;
+  CONTAINER_READ_NUMBER_CHECKED(reader(), "/memory.use_hierarchy", "Use Hierarchy", use_hierarchy);
+  return (jlong)use_hierarchy;
+}
+
 /*
  * The common case, containers, we have _root == _cgroup_path, and thus set the
  * controller path to the _mount_point. This is where the limits are exposed in
@@ -159,13 +165,13 @@ void verbose_log(julong read_mem_limit, julong host_mem) {
 jlong CgroupV1MemoryController::read_memory_limit_in_bytes(julong phys_mem) {
   julong memlimit;
   CONTAINER_READ_NUMBER_CHECKED(reader(), "/memory.limit_in_bytes", "Memory Limit", memlimit);
-  if (memlimit >= phys_mem) {
-    verbose_log(memlimit, phys_mem);
-    return (jlong)-1;
-  } else {
-    verbose_log(memlimit, phys_mem);
-    return (jlong)memlimit;
+  if (memlimit >= phys_mem && uses_mem_hierarchy()) {
+    CONTAINER_READ_NUMERICAL_KEY_VALUE_CHECKED(reader(), "/memory.stat",
+                                               "hierarchical_memory_limit", "Hierarchical Memory Limit",
+                                               memlimit);
   }
+  verbose_log(memlimit, phys_mem);
+  return (jlong)((memlimit < phys_mem) ? memlimit : -1);
 }
 
 /* read_mem_swap
@@ -183,12 +189,13 @@ jlong CgroupV1MemoryController::read_memory_limit_in_bytes(julong phys_mem) {
 jlong CgroupV1MemoryController::read_mem_swap(julong host_total_memsw) {
   julong memswlimit;
   CONTAINER_READ_NUMBER_CHECKED(reader(), "/memory.memsw.limit_in_bytes", "Memory and Swap Limit", memswlimit);
-  if (memswlimit >= host_total_memsw) {
-    log_trace(os, container)("Memory and Swap Limit is: Unlimited");
-    return (jlong)-1;
-  } else {
-    return (jlong)memswlimit;
+  if (memswlimit >= host_total_memsw && uses_mem_hierarchy()) {
+      CONTAINER_READ_NUMERICAL_KEY_VALUE_CHECKED(reader(), "/memory.stat",
+                                                 "hierarchical_memsw_limit", "Hierarchical Memory and Swap Limit",
+                                                 memswlimit);
   }
+  verbose_log(memswlimit, host_total_memsw);
+  return (jlong)((memswlimit < host_total_memsw) ? memswlimit : -1);
 }
 
 jlong CgroupV1MemoryController::memory_and_swap_limit_in_bytes(julong host_mem, julong host_swap) {

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -99,6 +99,7 @@ class CgroupV1MemoryController final : public CgroupMemoryController {
     const char* mount_point() override { return reader()->mount_point(); }
     const char* cgroup_path() override { return reader()->cgroup_path(); }
   private:
+    jlong uses_mem_hierarchy();
     jlong read_mem_swappiness();
     jlong read_mem_swap(julong host_total_memsw);
 


### PR DESCRIPTION
Reviewed-by: simonis, sgehwolf

Not a clean backport due to missing prerequisites. We can do the full commit chain upstream if they are willing to take that, but doing the minimal for the sake of expedience.