### PR TITLE
Add nightly sync for jdk25u-dev

### DIFF
--- a/.github/workflows/refresh-jdk-dev.yml
+++ b/.github/workflows/refresh-jdk-dev.yml
@@ -1,0 +1,37 @@
+name: "Refresh jdk from Upstream-dev"
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+env:
+  UPSTREAM_REMOTE: https://github.com/openjdk/jdk25u-dev
+  LOCAL_BRANCH: nightly
+
+jobs:
+    refresh-jdk:
+        runs-on: ubuntu-latest
+        name: "Update Corretto-25"
+        if: github.repository_owner == 'corretto'
+        steps:
+            - name: "Checkout code"
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+                ref: ${{ env.LOCAL_BRANCH }}
+
+            - name: "Configure the user"
+              run: |
+                git config user.email "no-reply@amazon.com"
+                git config user.name "corretto-github-robot"
+
+            - name: "Merge openjdk/jdk25u-dev:master to the corretto-25:nightly"
+              run: |
+                git fetch $UPSTREAM_REMOTE master || exit 1
+                git merge -m "Merge upstream-jdk25u-dev" FETCH_HEAD
+
+            - name: "Update Corretto version"
+              shell: bash
+              run: bash ./.github/scripts/update-version.sh $UPSTREAM_REMOTE
+
+            - name: "Push to the corretto-25"
+              run: git push origin $LOCAL_BRANCH

--- a/.github/workflows/refresh-jdk.yml
+++ b/.github/workflows/refresh-jdk.yml
@@ -35,3 +35,15 @@ jobs:
 
             - name: "Push to the corretto-25"
               run: git push origin $LOCAL_BRANCH
+
+            # Different merges to branches
+            - name: "Merge Corretto-25 develop to nightly"
+              shell: bash
+              run: |
+                git checkout nightly
+                git restore --source origin/$LOCAL_BRANCH --staged --worktree -- version.txt
+                git commit --allow-empty -m "Ephemeral commit: Automerged version.txt from $LOCAL_BRANCH to nightly"
+                ephemeral_commit=$(git rev-parse HEAD)
+                git merge origin/$LOCAL_BRANCH
+                git rebase --onto ${ephemeral_commit}^ ${ephemeral_commit}
+                git push origin nightly


### PR DESCRIPTION
https://github.com/openjdk/jdk25u-dev is live. 
Created nightly branch and added sync workflow for both jdk25u-dev to nightly and develop to nightly.
