### PR TITLE
8371368: SIGSEGV in JfrVframeStream::next_vframe() on arm64

### DIFF
--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampling.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampling.cpp
@@ -217,7 +217,8 @@ static bool compute_top_frame(const JfrSampleRequest& request, frame& top_frame,
           const PcDesc* const pc_desc = get_pc_desc(sampled_nm, sampled_pc);
           if (is_valid(pc_desc)) {
             intptr_t* const synthetic_sp = sender_sp - sampled_nm->frame_size();
-            top_frame = frame(synthetic_sp, synthetic_sp, sender_sp, pc_desc->real_pc(sampled_nm), sampled_nm);
+            intptr_t* const synthetic_fp = sender_sp AARCH64_ONLY( - frame::sender_sp_offset);
+            top_frame = frame(synthetic_sp, synthetic_sp, synthetic_fp, pc_desc->real_pc(sampled_nm), sampled_nm);
             in_continuation = is_in_continuation(top_frame, jt);
             return true;
           }

--- a/test/jdk/jdk/jfr/event/profiling/TestFullStackTrace.java
+++ b/test/jdk/jdk/jfr/event/profiling/TestFullStackTrace.java
@@ -32,6 +32,7 @@ import jdk.test.lib.jfr.EventNames;
  * @library /test/lib
  * @build jdk.jfr.event.profiling.BaseTestFullStackTrace
  * @run main/othervm jdk.jfr.event.profiling.TestFullStackTrace
+ * @run main/othervm -XX:CompileCommand=compileonly,jdk.test.lib.jfr.RecurseThread::recurse* -XX:+PreserveFramePointer jdk.jfr.event.profiling.TestFullStackTrace
  */
 public class TestFullStackTrace {
 


### PR DESCRIPTION
Pulling in https://github.com/openjdk/jdk25u-dev/commit/0a3249c488f77ceaec58b69348c59aff72814498 ahead of upstream 25.0.3 to unbreak some of our users. 

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `jdk_jfr`