### PR TITLE
8361699: C2: assert(can_reduce_phi(n->as_Phi())) failed: Sanity: previous reducible Phi is no longer reducible before SUT

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3129,6 +3129,14 @@ void ConnectionGraph::find_scalar_replaceable_allocs(GrowableArray<JavaObjectNod
               break;
             }
           }
+        } else if (use->is_LocalVar()) {
+          Node* phi = use->ideal_node();
+          if (phi->Opcode() == Op_Phi && reducible_merges.member(phi) && !can_reduce_phi(phi->as_Phi())) {
+            set_not_scalar_replaceable(jobj NOT_PRODUCT(COMMA "is merged in a non-reducible phi"));
+            reducible_merges.yank(phi);
+            found_nsr_alloc = true;
+            break;
+          }
         }
       }
     }

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationNotReducibleAnymore.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationNotReducibleAnymore.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8361699
+ * @summary Check that NSR state propagate correctly to initially reducible Phis
+ *          and turns them into non-reducible Phis.
+ * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationNotReducibleAnymore*::*
+ *                   -XX:CompileCommand=dontinline,*TestReduceAllocationNotReducibleAnymore*::*
+ *                   -Xcomp compiler.escapeAnalysis.TestReduceAllocationNotReducibleAnymore
+ * @run main compiler.escapeAnalysis.TestReduceAllocationNotReducibleAnymore
+ */
+
+package compiler.escapeAnalysis;
+
+public class TestReduceAllocationNotReducibleAnymore {
+    public static void main(String[] args) {
+        for (int i = 0; i < 100; i++) {
+            test(4, null);
+        }
+    }
+
+    static void test(int x, A a) {
+        Object[] objects = { new Object() };
+        Object object = new Object();
+        for (int i = 0; i < 150; i++) {
+            try {
+                objects[x] = object;
+                object = new byte[10];
+            } catch (ArrayIndexOutOfBoundsException e) {
+            }
+            try {
+                a.foo();
+            } catch (NullPointerException e) {
+            }
+        }
+    }
+
+    class A {
+        void foo() {}
+    }
+}


### PR DESCRIPTION
This cherry-picks https://git.openjdk.org/jdk25u-dev/commit/314a744ec516193f60bcda7fd5add7830ad51329, which lands in upstream `25.0.4`. We want this fix in Corretto 25.0.3 to unblock users.

Testing-wise, we rely on test we did upstream.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, new regression test fails without the fix, passes with it