### PR TITLE
8376104: C2 crashes in PhiNode::Ideal(PhaseGVN*, bool) accessing NULL pointer

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2580,6 +2580,10 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     for( uint i=1; i<req(); ++i ) {// For all paths in
       Node *ii = in(i);
       Node *new_in = MemNode::optimize_memory_chain(ii, at, nullptr, phase);
+      // MemNode::optimize_memory_chain above may kill us!
+      if (outcnt() == 0) {
+        return top;
+      }
       if (ii != new_in ) {
         set_req(i, new_in);
         progress = this;


### PR DESCRIPTION
This cherry-picks https://github.com/openjdk/jdk25u-dev/commit/2008683accbe783ccb8e19157c0794a8a3af8f2c ahead of upstream 25.0.3 to resolve JDK 25 regression seen in the wild.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `compiler/c2`
 - [x] Linux AArch64 server fastdebug, `all`