### PR TITLE
8369817: [TESTBUG] EmptyPath::toString is ignored

### DIFF
--- a/test/jdk/java/io/File/EmptyPath.java
+++ b/test/jdk/java/io/File/EmptyPath.java
@@ -382,9 +382,8 @@ public class EmptyPath {
     }
 
     @Test
-    public String toString() {
+    public void testToString() {
         assertEquals(EMPTY_STRING, f.toString());
-        return EMPTY_STRING;
     }
 
     @Test


### PR DESCRIPTION
Backport-of: 008d8d914cd4dd4573361390ee31120134338802

Cherry-picking test fix for test/jdk/java/io/File/EmptyPath.java in advance of the 2026 Q2 release.