### PR TITLE
Improve gha script develop -> nightly merge

### DIFF
--- a/.github/workflows/refresh-jdk.yml
+++ b/.github/workflows/refresh-jdk.yml
@@ -44,9 +44,16 @@ jobs:
               shell: bash
               run: |
                 git checkout nightly
-                git restore --source origin/$LOCAL_BRANCH --staged --worktree -- version.txt
-                git commit --allow-empty -m "Ephemeral commit: Automerged version.txt from $LOCAL_BRANCH to nightly"
-                ephemeral_commit=$(git rev-parse HEAD)
-                git merge origin/$LOCAL_BRANCH
-                git rebase --onto ${ephemeral_commit}^ ${ephemeral_commit}
+                if ! git merge --no-ff --no-commit origin/$LOCAL_BRANCH; then
+                  # The only conflict we expect/accept is version.txt
+                  unmerged=$(git diff --name-only --diff-filter=U)
+                  if [ "$unmerged" != "version.txt" ]; then
+                    echo "Unexpected merge conflicts: $unmerged" >&2
+                    exit 1
+                  fi
+                fi
+                # Always keep nightly's version.txt — whether the merge was clean or conflicted
+                git checkout HEAD -- version.txt
+                git add version.txt
+                git commit -m "Merge $LOCAL_BRANCH into nightly" || echo "Nothing to merge; nightly up to date"
                 git push origin nightly


### PR DESCRIPTION
### Description
The old develop -> nightly merge script would fail on version.txt merge conflicts, and even after manual resolving the rebase, the subsequent reruns of the script would fail as it would be a no-op push/commit.

### Related issues
n/a

### Motivation and context
See description

### How has this been tested?
I used this to resolve the last corretto-21 merge conflict. This will be backported to other LTS versions.
https://github.com/corretto/corretto-21/commit/7c0c06b4bc82141b0d4a7d8a87e90c7d5dc463d0

### Platform information
    Works on OS: n/a
    Applies to version n/a


### Additional context
n/a