### PR TITLE
Pulling debugsymbols from symbols directory

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -324,6 +324,9 @@ install -d -m 755 %{buildroot}%{java_home}
 cp -a %{java_imgdir}/jdk/* %{buildroot}%{java_home}
 rm -rf %{buildroot}%{java_home}/demo
 
+# Install debugsymbols
+cp -a %{java_imgdir}/symbols/* %{buildroot}%{java_home}
+
 # Properly set permissions for executables and libs to enable auto-provides scanning
 find %{buildroot}%{java_home}/ -name "*.so" -exec chmod 755 \\{\\} \\; ;
 find %{buildroot}%{java_home} -type d -exec chmod 755 \\{\\} \\; ;

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -40,6 +40,7 @@ ext {
     }
 }
 def jdkResultingImage = "$buildRoot/build/linux-${arch}-server-${correttoDebugLevel}/images/jdk"
+def debugSymbolsResultingImage = "$buildRoot/build/linux-${arch}-server-${correttoDebugLevel}/images/symbols"
 def testResultingImage = "$buildRoot/build/linux-${arch}-server-${correttoDebugLevel}/images/test"
 
 // deps
@@ -145,7 +146,7 @@ task packageDebugSymbols(type: Tar) {
     description = 'Package debug symbols'
     archiveFileName = "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
     compression = Compression.GZIP
-    from(jdkResultingImage) {
+    from(debugSymbolsResultingImage) {
         include 'bin/*.diz'
         include 'lib/*.diz'
         include 'lib/server/*.diz'

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -30,6 +30,7 @@ if (project.correttoArch == 'x86') {
 
 def imageDir = "$buildRoot/build/${project.jdkImageName}/images"
 def jdkResultingImage = "${imageDir}/jdk"
+def debugSymbolsResultingImage = "${imageDir}/symbols"
 def testResultingImage = "${imageDir}/test"
 
 // deps
@@ -157,7 +158,7 @@ task packageDebugSymbols(type: Tar) {
     dependsOn packageTestImage
     archiveFileName = "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression = Compression.GZIP
-    from(jdkResultingImage) {
+    from(debugSymbolsResultingImage) {
         include 'bin/*.diz'
         include 'lib/*.diz'
         include 'lib/server/*.diz'

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -33,6 +33,7 @@ configurations {
 // consts
 def imageDir= "$buildRoot/build/${project.jdkImageName}/images"
 def jdkResultingImage = "${imageDir}/jdk-bundle"
+def debugSymbolsResultingImage = "${imageDir}/symbols"
 def testResultingImage = "${imageDir}/test"
 def correttoMacDir = "amazon-corretto-${project.version.major}.jdk"
 
@@ -196,10 +197,10 @@ task packageDebugSymbols(type: Tar) {
     description 'Package debug symbols'
     archiveFileName = "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression Compression.GZIP
-    from("${jdkResultingImage}/${correttoMacDir}") {
-        include "Contents/Home/bin/*.diz"
-        include "Contents/Home/lib/*.diz"
-        include "Contents/Home/lib/server/*.diz"
+    from("${debugSymbolsResultingImage}") {
+        include "bin/*.diz"
+        include "lib/*.diz"
+        include "lib/server/*.diz"
     }
     into "${buildDir}/${correttoMacDir}"
     into project.correttoDebugSymbolsArchiveName

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
 def imageDir = "$buildRoot/build/${project.jdkImageName}/images"
 def jdkResultingImage = "${imageDir}/jdk"
+def debugSymbolsResultingImage = "${imageDir}/symbols"
 def testResultingImage = "${imageDir}/test"
 
 // deps
@@ -80,7 +81,7 @@ task packageDebugSymbols(type: Zip) {
     dependsOn packageTestImage
     archiveFileName = "${project.correttoDebugSymbolsArchiveName}.zip"
 
-    from(jdkResultingImage) {
+    from(debugSymbolsResultingImage) {
         include 'bin/*.diz'
         include 'lib/*.diz'
         include 'lib/server/*.diz'


### PR DESCRIPTION
clean backport of: https://github.com/corretto/corretto-jdk/pull/151