### PR TITLE
Gzipinputstream downports and restoring of multi-member read behavior

### DIFF
--- a/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,22 @@ import java.util.Objects;
  */
 public class GZIPInputStream extends InflaterInputStream {
     /**
-     * CRC-32 for uncompressed data.
+     * GZIP header magic number.
+     */
+    public static final int GZIP_MAGIC = 0x8b1f;
+
+    /*
+     * File header flags.
+     */
+    private static final int FHCRC      = 2;    // Header CRC
+    private static final int FEXTRA     = 4;    // Extra field
+    private static final int FNAME      = 8;    // File name
+    private static final int FCOMMENT   = 16;   // File comment
+
+    private final byte[] tmpbuf = new byte[128];
+
+    /**
+     * CRC-32 for decompressed data.
      */
     protected CRC32 crc = new CRC32();
 
@@ -173,20 +188,6 @@ public class GZIPInputStream extends InflaterInputStream {
         }
     }
 
-    /**
-     * GZIP header magic number.
-     */
-    public static final int GZIP_MAGIC = 0x8b1f;
-
-    /*
-     * File header flags.
-     */
-    private static final int FTEXT      = 1;    // Extra text
-    private static final int FHCRC      = 2;    // Header CRC
-    private static final int FEXTRA     = 4;    // Extra field
-    private static final int FNAME      = 8;    // File name
-    private static final int FCOMMENT   = 16;   // File comment
-
     /*
      * Reads GZIP member header and returns the total byte number
      * of this member header.
@@ -308,8 +309,6 @@ public class GZIPInputStream extends InflaterInputStream {
         }
         return b;
     }
-
-    private byte[] tmpbuf = new byte[128];
 
     /*
      * Skips bytes of input data blocking until all bytes are skipped.

--- a/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
@@ -60,7 +60,7 @@ public class GZIPInputStream extends InflaterInputStream {
     // system property which configures whether we skip the call to InputStream.available()
     // when checking for additional GZIP members in a stream
     private static final boolean alwaysReadNextMember =
-            Boolean.getBoolean("jdk.util.gzip.tryReadAheadAfterTrailer");
+            Boolean.parseBoolean(System.getProperty("jdk.util.gzip.tryReadAheadAfterTrailer", "True"));
 
     /**
      * GZIP header magic number.

--- a/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
@@ -37,12 +37,31 @@ import java.util.Objects;
  * This class implements a stream filter for reading compressed data in
  * the GZIP file format.
  *
+ * @implNote
+ * After reading a member trailer, the {@linkplain #read(byte[], int, int) read} method calls
+ * {@link InputStream#available()} on the underlying stream to determine whether additional
+ * bytes are available that may represent a subsequent member. If the
+ * {@systemProperty jdk.util.gzip.tryReadAheadAfterTrailer} system property is set
+ * to {@code true}, then the call to {@code InputStream.available()} is skipped and the
+ * implementation instead attempts to read a subsequent member in the stream.
+ * {@code GZIPInputStream} depends on the return value of {@code InputStream.available()}
+ * to reliably process a stream with a series of members. Consequently, it may be necessary
+ * to set this property in environments that process streams with a series of members. By default,
+ * the {@code jdk.util.gzip.tryReadAheadAfterTrailer} system property is not set, and
+ * {@code InputStream.available()} gets called.
+ *
  * @see         InflaterInputStream
  * @author      David Connelly
  * @since 1.1
  *
  */
 public class GZIPInputStream extends InflaterInputStream {
+
+    // system property which configures whether we skip the call to InputStream.available()
+    // when checking for additional GZIP members in a stream
+    private static final boolean alwaysReadNextMember =
+            Boolean.getBoolean("jdk.util.gzip.tryReadAheadAfterTrailer");
+
     /**
      * GZIP header magic number.
      */
@@ -94,7 +113,11 @@ public class GZIPInputStream extends InflaterInputStream {
         super(in, createInflater(in, size), size);
         usesDefaultInflater = true;
         try {
-            readHeader(in);
+            // we don't expect the stream to be at EOF
+            // and if it is, then we want readHeader to
+            // raise an exception, so we pass "true" for
+            // the "failOnEOF" param.
+            readHeader(in, true);
         } catch (IOException ioe) {
             this.inf.end();
             throw ioe;
@@ -165,10 +188,15 @@ public class GZIPInputStream extends InflaterInputStream {
         }
         int n = super.read(buf, off, len);
         if (n == -1) {
-            if (readTrailer())
+            if (hasNoMoreMembers()) {
                 eos = true;
-            else
+            } else {
+                // When a next member is available, hasNoMoreMembers() will read
+                // its header and will position the stream at the next member's
+                // deflated data. We now decompress and return that member's
+                // decompressed data.
                 return this.read(buf, off, len);
+            }
         } else {
             crc.update(buf, off, n);
         }
@@ -191,12 +219,40 @@ public class GZIPInputStream extends InflaterInputStream {
     /*
      * Reads GZIP member header and returns the total byte number
      * of this member header.
+     * If failOnEOF is false and if the given InputStream has already
+     * reached EOF when this method was invoked, then this method returns
+     * -1 (indicating that there's no GZIP member header).
+     * In all other cases of malformed header or EOF being detected
+     * when reading the header, this method will throw an IOException.
      */
-    private int readHeader(InputStream this_in) throws IOException {
-        CheckedInputStream in = new CheckedInputStream(this_in, crc);
+    private int readHeader(InputStream stream, boolean failOnEOF) throws IOException {
+        CheckedInputStream in = new CheckedInputStream(stream, crc);
         crc.reset();
+
+        int magic;
+        if (!failOnEOF) {
+            // read an unsigned short value representing the GZIP magic header.
+            // this is the same as calling readUShort(in), except that here,
+            // when reading the first byte, we don't raise an EOFException
+            // if the stream has already reached EOF.
+
+            // read unsigned byte
+            int b = in.read();
+            if (b == -1) { // EOF
+                crc.reset();
+                return -1; // represents no header bytes available
+            }
+            checkUnexpectedByte(b);
+            // read the next unsigned byte to form the unsigned
+            // short. we throw the usual EOFException/ZipException
+            // from this point on if there is no more data or
+            // the data doesn't represent a header.
+            magic = (readUByte(in) << 8) | b;
+        } else {
+            magic = readUShort(in);
+        }
         // Check header magic
-        if (readUShort(in) != GZIP_MAGIC) {
+        if (magic != GZIP_MAGIC) {
             throw new ZipException("Not in GZIP format");
         }
         // Check compression method
@@ -238,44 +294,66 @@ public class GZIPInputStream extends InflaterInputStream {
         return n;
     }
 
-    /*
-     * Reads GZIP member trailer and returns true if the eos
-     * reached, false if there are more (concatenated gzip
-     * data set)
+    /**
+     * Reads the current GZIP member's trailer and returns true if the end-of-stream is
+     * reached. After reading the current member's trailer, if the stream has a subsequent
+     * GZIP member, then this method reads that member's header and returns false indicating
+     * that there is another member in the stream.
      */
-    private boolean readTrailer() throws IOException {
-        InputStream in = this.in;
-        int n = inf.getRemaining();
-        if (n > 0) {
-            in = new SequenceInputStream(
-                        new ByteArrayInputStream(buf, len - n, n),
-                        new FilterInputStream(in) {
-                            public void close() throws IOException {}
-                        });
+    private boolean hasNoMoreMembers() throws IOException {
+        final int numRemainingInInflater = inf.getRemaining();
+        InputStream stream = this.in;
+        if (numRemainingInInflater > 0) {
+            stream = new SequenceInputStream(
+                    new ByteArrayInputStream(buf, len - numRemainingInInflater, numRemainingInInflater),
+                    new FilterInputStream(stream) {
+                        public void close() {}
+                    });
         }
-        // Uses left-to-right evaluation order
-        if ((readUInt(in) != crc.getValue()) ||
-            // rfc1952; ISIZE is the input size modulo 2^32
-            (readUInt(in) != (inf.getBytesWritten() & 0xffffffffL)))
-            throw new ZipException("Corrupt GZIP trailer");
-
-        // If there are more bytes available in "in" or
-        // the leftover in the "inf" is > 26 bytes:
-        // this.trailer(8) + next.header.min(10) + next.trailer(8)
-        // try concatenated case
-        if (this.in.available() > 0 || n > 26) {
-            int m = 8;                  // this.trailer
-            try {
-                m += readHeader(in);    // next.header
-            } catch (IOException ze) {
-                return true;  // ignore any malformed, do nothing
+        // first read the current member's trailer
+        readTrailer(stream);
+        // decide whether to read next member's header
+        final boolean readNextMember = alwaysReadNextMember
+                || this.in.available() > 0
+                || numRemainingInInflater > 26; // current member's trailer == 8 bytes
+                                                // + minimum of 10 bytes header for next member
+                                                // + mandatory 8 bytes from next member's trailer
+                                                // == at least 26 bytes needed for next member to
+                                                // be present
+        if (!readNextMember) {
+            return true; // no need to read next member
+        }
+        // read next member's header
+        int m = 8;  // this.trailer
+        try {
+            int numNextHeaderBytes = readHeader(stream, false); // next.header (if available)
+            if (numNextHeaderBytes == -1) {
+                return true; // end of stream reached, no more members
             }
-            inf.reset();
-            if (n > m)
-                inf.setInput(buf, len - n + m, n - m);
-            return false;
+            m += numNextHeaderBytes;
+        } catch (IOException ze) {
+            return true;  // ignore any malformed, consider it as no more members in the stream
         }
-        return true;
+        inf.reset(); // reset the inflater for fresh input data from the next member
+        if (numRemainingInInflater > m) {
+            // position the inflater's input buffer to the start of next member's deflated data
+            inf.setInput(buf, len - numRemainingInInflater + m, numRemainingInInflater - m);
+        }
+        return false; // next member exists
+    }
+
+    /**
+     * Reads the current member's trailer
+     *
+     * @param stream the InputStream containing the trailer
+     */
+    private void readTrailer(final InputStream stream) throws IOException {
+        // Uses left-to-right evaluation order
+        if ((readUInt(stream) != crc.getValue()) ||
+                // rfc1952; ISIZE is the input size modulo 2^32
+                (readUInt(stream) != (inf.getBytesWritten() & 0xffffffffL))) {
+            throw new ZipException("Corrupt GZIP trailer");
+        }
     }
 
     /*
@@ -302,12 +380,16 @@ public class GZIPInputStream extends InflaterInputStream {
         if (b == -1) {
             throw new EOFException();
         }
-        if (b < -1 || b > 255) {
-            // Report on this.in, not argument in; see read{Header, Trailer}.
-            throw new IOException(this.in.getClass().getName()
-                + ".read() returned value out of range -1..255: " + b);
-        }
+        checkUnexpectedByte(b);
         return b;
+    }
+
+    private void checkUnexpectedByte(final int b) throws IOException {
+        if (b < -1 || b > 255) {
+            // report the InputStream type which returned this unexpected byte
+            throw new IOException(this.in.getClass().getName()
+                    + ".read() returned value out of range -1..255: " + b);
+        }
     }
 
     /*

--- a/test/jdk/java/util/zip/GZIP/BasicGZIPInputStreamTest.java
+++ b/test/jdk/java/util/zip/GZIP/BasicGZIPInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,21 @@
  */
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /*
  * @test
@@ -51,7 +57,7 @@ public class BasicGZIPInputStreamTest {
     @ParameterizedTest
     @MethodSource("npeFromConstructors")
     public void testNPEFromConstructors(final Executable constructor) {
-        Assertions.assertThrows(NullPointerException.class, constructor,
+        assertThrows(NullPointerException.class, constructor,
                 "GZIPInputStream constructor did not throw NullPointerException");
     }
 
@@ -71,7 +77,7 @@ public class BasicGZIPInputStreamTest {
     @ParameterizedTest
     @MethodSource("iaeFromConstructors")
     public void testIAEFromConstructors(final Executable constructor) {
-        Assertions.assertThrows(IllegalArgumentException.class, constructor,
+        assertThrows(IllegalArgumentException.class, constructor,
                 "GZIPInputStream constructor did not throw IllegalArgumentException");
     }
 
@@ -89,7 +95,29 @@ public class BasicGZIPInputStreamTest {
     @ParameterizedTest
     @MethodSource("ioeFromConstructors")
     public void testIOEFromConstructors(final Executable constructor) {
-        Assertions.assertThrows(IOException.class, constructor,
+        assertThrows(IOException.class, constructor,
                 "GZIPInputStream constructor did not throw IOException");
+    }
+
+    /*
+     * Verifies that GZIPInputStream.read() throws IOException when invoked on a closed
+     * stream
+     */
+    @Test
+    void testClosedStreamRead() throws Exception {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzos = new GZIPOutputStream(baos)) {
+            gzos.write(new byte[] {0x42, 0x42}); // GZIP compress these input bytes
+        }
+        final byte[] gzipCompressed = baos.toByteArray();
+        // create the GZIPInputStream to test
+        final GZIPInputStream in = new GZIPInputStream(new ByteArrayInputStream(gzipCompressed));
+        in.close();
+        final IOException ioe = assertThrows(IOException.class, () -> in.read(new byte[1], 0, 1));
+        final String exMessage = ioe.getMessage();
+        if (exMessage == null || !exMessage.contains("Stream closed")) {
+            // unexpected exception message, propagate the original exception
+            throw ioe;
+        }
     }
 }

--- a/test/jdk/java/util/zip/GZIP/GZIPInputStreamCallsAvailable.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPInputStreamCallsAvailable.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Random;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import jdk.test.lib.RandomFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/*
+ * @test
+ * @summary Verify the behaviour of GZIPInputStream when dealing with InputStream.available()
+ *          on the underlying stream and the jdk.util.gzip.tryReadAheadAfterTrailer
+ *          system property being enabled/disabled
+ * @key randomness
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run junit/othervm -Djdk.util.gzip.tryReadAheadAfterTrailer=true GZIPInputStreamCallsAvailable
+ * @run junit/othervm -Djdk.util.gzip.tryReadAheadAfterTrailer=false GZIPInputStreamCallsAvailable
+ * @run junit GZIPInputStreamCallsAvailable
+ */
+class GZIPInputStreamCallsAvailable {
+
+    private static final boolean AVAILABLE_METHOD_INVOCATION_SKIPPED =
+            Boolean.getBoolean("jdk.util.gzip.tryReadAheadAfterTrailer");
+    private static final Random random = RandomFactory.getRandom();
+
+    private record TestData(byte[] uncompressed, byte[] compressed) {
+    }
+
+    static List<Integer> numGZIPMembers() {
+        return List.of(1,
+                33,
+                random.nextInt(2, 1001) // a reasonably large number of members
+        );
+    }
+
+    /*
+     * Verify that GZIPInputStream reads and returns the correct decompressed data when:
+     *  - the underlying InputStream.available() returns an accurate value
+     *  - and when the GZIPInputStream isn't expected to call the underlying InputStream.available()
+     *    method
+     */
+    @ParameterizedTest
+    @MethodSource("numGZIPMembers")
+    void testMultipleMembers(final int numMembers) throws IOException {
+        final TestData testData = createGZIPStream(numMembers);
+        final InputStream underlyingStream = AVAILABLE_METHOD_INVOCATION_SKIPPED
+                // stream whose available() method isn't expected to be invoked
+                ? new AlwaysThrowFromAvailable(new ByteArrayInputStream(testData.compressed))
+                // stream whose available() will be invoked and returns an accurate value
+                : new ByteArrayInputStream(testData.compressed);
+        try (GZIPInputStream gzip = new GZIPInputStream(underlyingStream)) {
+            final byte[] decompressed = gzip.readAllBytes();
+            assertArrayEquals(testData.uncompressed, decompressed, "unexpected decompressed data");
+        }
+    }
+
+    /*
+     * Creates and returns bytes representing a GZIP stream consisting of the given number of
+     * members.
+     */
+    private static TestData createGZIPStream(final int numMembers) throws IOException {
+        final String content = "foo bar hello world from " + GZIPInputStreamCallsAvailable.class;
+        final ByteArrayOutputStream uncompressed = new ByteArrayOutputStream();
+        final ByteArrayOutputStream gzipped = new ByteArrayOutputStream();
+        for (int i = 1; i <= numMembers; i++) {
+            final ByteArrayOutputStream member = new ByteArrayOutputStream();
+            try (final OutputStream gzip = new GZIPOutputStream(member)) {
+                final byte[] memberRawBytes = ("member-" + i + " " + content).getBytes(US_ASCII);
+                gzip.write(memberRawBytes);
+                // keep track of the uncompressed content too so that it can be compared for
+                // equality with the decompressed content
+                uncompressed.write(memberRawBytes);
+            }
+            // write out the GZIP member to the stream which accumulates all the members
+            gzipped.write(member.toByteArray());
+        }
+        return new TestData(uncompressed.toByteArray(), gzipped.toByteArray());
+    }
+
+    private static class AlwaysThrowFromAvailable extends FilterInputStream {
+        public AlwaysThrowFromAvailable(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public int available() {
+            throw new AssertionError(this.getClass().getName()
+                    + ".available() wasn't expected to be invoked");
+        }
+    }
+}

--- a/test/jdk/java/util/zip/GZIP/GZIPInputStreamRead.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPInputStreamRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,81 +21,201 @@
  * questions.
  */
 
-/* @test
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import jdk.test.lib.RandomFactory;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * @test
  * @bug 4691425
  * @summary Test the read and write of GZIPInput/OutputStream, including
  *          concatenated .gz inputstream
  * @key randomness
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run junit ${test.main.class}
  */
+class GZIPInputStreamRead {
 
-import java.io.*;
-import java.util.*;
-import java.util.zip.*;
+    private static final Random random = RandomFactory.getRandom();
 
-public class GZIPInputStreamRead {
-    public static void main(String[] args) throws Throwable {
-        Random rnd = new Random();
-        for (int i = 1; i < 100; i++) {
-            int members = rnd.nextInt(10) + 1;
+    /*
+     * Generates GZIP content containing multiple members and then verifies
+     * that using GZIPInputStream to decompress that content generates the correct
+     * expected decompressed data.
+     */
+    @Test
+    void testMultipleMembers() throws Exception {
+        final int numMembers = random.nextInt(10) + 1;
+        final ByteArrayOutputStream rawUncompressedBaos = new ByteArrayOutputStream();
+        final ByteArrayOutputStream gzipCompressedBaos = new ByteArrayOutputStream();
+        // generate GZIP content with multiple members
+        for (int j = 0; j < numMembers; j++) {
+            byte[] src = new byte[random.nextInt(8192) + 1];
+            random.nextBytes(src);
+            rawUncompressedBaos.write(src);
 
-            ByteArrayOutputStream srcBAOS = new ByteArrayOutputStream();
-            ByteArrayOutputStream dstBAOS = new ByteArrayOutputStream();
-            for (int j = 0; j < members; j++) {
-                byte[] src = new byte[rnd.nextInt(8192) + 1];
-                rnd.nextBytes(src);
-                srcBAOS.write(src);
-
-                try (GZIPOutputStream gzos = new GZIPOutputStream(dstBAOS)) {
-                    gzos.write(src);
-                }
+            try (GZIPOutputStream gzos = new GZIPOutputStream(gzipCompressedBaos)) {
+                gzos.write(src);
             }
-            byte[] srcBytes = srcBAOS.toByteArray();
-            byte[] dstBytes = dstBAOS.toByteArray();
-            // try different size of buffer to read the
-            // GZIPInputStream
-            /* just for fun when running manually
-            for (int j = 1; j < 10; j++) {
-                test(srcBytes, dstBytes, j);
-            }
-            */
-            for (int j = 0; j < 10; j++) {
-                int readBufSZ = rnd.nextInt(2048) + 1;
-                test(srcBytes,
-                     dstBytes,
-                     readBufSZ,
-                     512);    // the defualt buffer size
-                test(srcBytes,
-                     dstBytes,
-                     readBufSZ,
-                     rnd.nextInt(4096) + 1);
-            }
+        }
+        final byte[] uncompressedRawBytes = rawUncompressedBaos.toByteArray();
+        final byte[] gzipCompressedBytes = gzipCompressedBaos.toByteArray();
+        // decompress using GZIPInputStream and verify the decompressed output.
+        // use different input buffer size for GZIPInputStream when running the verification.
+        for (int j = 0; j < 10; j++) {
+            final int readBufSZ = random.nextInt(2048) + 1;
+            verifyDecompressed(uncompressedRawBytes,
+                    gzipCompressedBytes,
+                    readBufSZ,
+                    512);    // the default input buffer size
+            verifyDecompressed(uncompressedRawBytes,
+                    gzipCompressedBytes,
+                    readBufSZ,
+                    random.nextInt(4096) + 1);
         }
     }
 
-    private static void test(byte[] src, byte[] dst,
-                             int readBufSize, int gzisBufSize)
-        throws Throwable
-    {
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(dst);
-             GZIPInputStream gzis = new GZIPInputStream(bais, gzisBufSize))
-        {
-            byte[] result = new byte[src.length + 10];
+    /*
+     * Generates GZIP content containing one member followed by some arbitrary non-member data.
+     * The test then verifies that using GZIPInputStream to decompress that content generates
+     * the correct expected decompressed data.
+     */
+    @Test
+    void testNonMemberAfterTrailer() throws Exception {
+        final byte[] rawUncompressed = new byte[random.nextInt(1234)];
+        random.nextBytes(rawUncompressed);
+        final ByteArrayOutputStream gzipCompressedPlusExtra = new ByteArrayOutputStream();
+        // generate a valid GZIP member
+        try (GZIPOutputStream gzos = new GZIPOutputStream(gzipCompressedPlusExtra)) {
+            gzos.write(rawUncompressed); // GZIP compress
+        }
+        final int numCompressedBytes = gzipCompressedPlusExtra.size();
+        // past the GZIP trailer, write some additional bytes that doesn't represent a GZIP member
+        final byte[] notGZIPMagic = ByteBuffer.allocate(Integer.BYTES).
+                putInt(GZIPInputStream.GZIP_MAGIC + 42)
+                .array();
+        gzipCompressedPlusExtra.write(notGZIPMagic);
+        assertEquals(numCompressedBytes + notGZIPMagic.length, gzipCompressedPlusExtra.size(),
+                "unexpected number of compressed + extra bytes");
+        // now use GZIPInputStream to decompress the compressed plus extra bytes and verify
+        // that the extra bytes don't cause unexpected decompressed output
+        final ByteArrayOutputStream decompressedBaos = new ByteArrayOutputStream();
+        int n = 0;
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(gzipCompressedPlusExtra.toByteArray());
+             GZIPInputStream gzipIn = new GZIPInputStream(bais)) {
+
+            final byte[] tmpBuf = new byte[42];
+            while ((n = gzipIn.read(tmpBuf)) != -1) {
+                decompressedBaos.write(tmpBuf, 0, n);
+            }
+            final byte[] decompressed = decompressedBaos.toByteArray();
+            // verify the decompressed content
+            assertEquals(rawUncompressed.length, decompressed.length,
+                    "unexpected number of decompressed bytes");
+            assertArrayEquals(rawUncompressed, decompressed, "unexpected decompressed data");
+            // make sure additional calls to read still return EOF
+            assertEquals(-1, gzipIn.read(), "unexpected return from read(), expected EOF");
+            assertEquals(-1, gzipIn.read(new byte[10]), "unexpected return from read(), expected EOF");
+        }
+    }
+
+    /*
+     * Verifies that the InputStream.available() method is invoked on the underlying InputStream
+     * to determine presence of additional GZIP members in the stream.
+     */
+    @Test
+    void testInputStreamAvailableCalled() throws Exception {
+        final byte[] rawUncompressedMember1 = new byte[random.nextInt(111)];
+        random.nextBytes(rawUncompressedMember1);
+        System.err.println("GZIP member 1 has " + rawUncompressedMember1.length + " bytes");
+
+        final byte[] rawUncompressedMember2 = new byte[random.nextInt(33)];
+        random.nextBytes(rawUncompressedMember2);
+        System.err.println("GZIP member 2 has " + rawUncompressedMember2.length + " bytes");
+
+        final ByteArrayOutputStream twoMemberGzipCompressedBaos = new ByteArrayOutputStream();
+        // generate GZIP format data with 2 valid GZIP members
+        try (GZIPOutputStream gzos = new GZIPOutputStream(twoMemberGzipCompressedBaos)) {
+            gzos.write(rawUncompressedMember1); // GZIP compress
+            gzos.write(rawUncompressedMember2); // GZIP compress
+        }
+        final byte[] gzipCompressed = twoMemberGzipCompressedBaos.toByteArray();
+        final AtomicBoolean availableInvoked = new AtomicBoolean();
+        // an InputStream which tracks the calls to available()
+        final ByteArrayInputStream underlying = new ByteArrayInputStream(gzipCompressed) {
+            @Override
+            public int available() {
+                availableInvoked.set(true);
+                return super.available();
+            }
+        };
+        // now use GZIPInputStream to decompress the compressed data and expect the decompressed
+        // data to be correct and also expect the InputStream.available() to have been invoked
+        final ByteArrayOutputStream decompressedBaos = new ByteArrayOutputStream();
+        int n = 0;
+        try (GZIPInputStream gzipIn = new GZIPInputStream(underlying)) {
+
+            final byte[] tmpBuf = new byte[1024];
+            while ((n = gzipIn.read(tmpBuf)) != -1) {
+                decompressedBaos.write(tmpBuf, 0, n);
+            }
+            assertTrue(availableInvoked.get(), "InputStream.available() wasn't invoked");
+            final byte[] decompressed = decompressedBaos.toByteArray();
+            // verify the decompressed content, it should represent the two GZIP members
+            assertEquals(rawUncompressedMember1.length + rawUncompressedMember2.length,
+                    decompressed.length, "unexpected number of decompressed bytes");
+
+            assertArrayEquals(rawUncompressedMember1,
+                    Arrays.copyOfRange(decompressed, 0, rawUncompressedMember1.length),
+                    "unexpected decompressed data of first member");
+
+            assertArrayEquals(rawUncompressedMember2,
+                    Arrays.copyOfRange(decompressed, rawUncompressedMember1.length, decompressed.length),
+                    "unexpected decompressed data of second member");
+
+            // make sure additional calls to read still return EOF
+            assertEquals(-1, gzipIn.read(), "unexpected return from read(), expected EOF");
+            assertEquals(-1, gzipIn.read(new byte[42]), "unexpected return from read(), expected EOF");
+        }
+    }
+
+    // verify that decompressing the gzipCompressed data using GZIPInputStream
+    // generates the expected output
+    private static void verifyDecompressed(final byte[] rawUncompressed,
+                                           final byte[] gzipCompressed,
+                                           final int readBufSize, final int gzisBufSize)
+            throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(gzipCompressed);
+             GZIPInputStream gzis = new GZIPInputStream(bais, gzisBufSize)) {
+
+            byte[] result = new byte[rawUncompressed.length + 10];
             byte[] buf = new byte[readBufSize];
             int n = 0;
-            int off = 0;
-
+            int numDecompressed = 0;
             while ((n = gzis.read(buf, 0, buf.length)) != -1) {
-                System.arraycopy(buf, 0, result, off, n);
-                off += n;
+                System.arraycopy(buf, 0, result, numDecompressed, n);
+                numDecompressed += n;
                 // no range check, if overflow, let it fail
             }
-            if (off != src.length || gzis.available() != 0 ||
-                !Arrays.equals(src, Arrays.copyOf(result, off))) {
-                throw new RuntimeException(
-                    "GZIPInputStream reading failed! " +
-                    ", src.len=" + src.length +
-                    ", read=" + off);
-            }
+            assertEquals(rawUncompressed.length, numDecompressed,
+                    "unexpected number of decompressed bytes");
+            assertEquals(0, gzis.available(),
+                    "unexpected additional bytes available in the GZIPInputStream");
+            assertArrayEquals(rawUncompressed, Arrays.copyOf(result, numDecompressed),
+                    "unexpected decompressed data");
         }
     }
 }

--- a/test/jdk/java/util/zip/GZIP/GZIPInputStreamRead.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPInputStreamRead.java
@@ -24,6 +24,7 @@
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
@@ -45,11 +46,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @key randomness
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
+ * @modules java.base/java.util.zip:open
  * @run junit ${test.main.class}
  */
 class GZIPInputStreamRead {
 
     private static final Random random = RandomFactory.getRandom();
+
+    // 'GZIPInputStream.alwaysReadNextMember' configures whether GZIPInputStream skips the call to
+    // 'InputStream.available()' when checking for additional GZIP members in a stream. Tests which
+    // specifically test the non-blocking behavior (i.e. for the 'alwaysReadNextMember=false' case)
+    // have to be skipped if 'GZIPInputStream.alwaysReadNextMember' is 'true'.
+    static boolean alwaysReadNextMember = false;
+    static {
+        try {
+            Field alwaysReadNextMemberField = GZIPInputStream.class.getDeclaredField("alwaysReadNextMember");
+            alwaysReadNextMemberField.setAccessible(true);
+            alwaysReadNextMember = alwaysReadNextMemberField.getBoolean(null);
+        } catch (Exception e) {
+            System.out.println("Warning: can't get value of 'GZIPInputStream.alwaysReadNextMember'");
+            e.printStackTrace(System.out);
+        }
+    }
 
     /*
      * Generates GZIP content containing multiple members and then verifies
@@ -172,7 +190,9 @@ class GZIPInputStreamRead {
             while ((n = gzipIn.read(tmpBuf)) != -1) {
                 decompressedBaos.write(tmpBuf, 0, n);
             }
-            assertTrue(availableInvoked.get(), "InputStream.available() wasn't invoked");
+            if (!alwaysReadNextMember) {
+              assertTrue(availableInvoked.get(), "InputStream.available() wasn't invoked");
+            }
             final byte[] decompressed = decompressedBaos.toByteArray();
             // verify the decompressed content, it should represent the two GZIP members
             assertEquals(rawUncompressedMember1.length + rawUncompressedMember2.length,

--- a/test/jdk/java/util/zip/GZIP/GZIPOverBlockingStreams.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPOverBlockingStreams.java
@@ -63,6 +63,9 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @library /test/lib
  * @build jdk.test.lib.net.URIBuilder jdk.test.lib.RandomFactory
  * @run junit GZIPOverBlockingStreams
+ * @comment verify it behaves the same when jdk.util.gzip.tryReadAheadAfterTrailer system property
+ *          is set to false
+ * @run junit/othervm -Djdk.util.gzip.tryReadAheadAfterTrailer=false GZIPOverBlockingStreams
  */
 class GZIPOverBlockingStreams {
 

--- a/test/jdk/java/util/zip/GZIP/GZIPOverBlockingStreams.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPOverBlockingStreams.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import jdk.test.lib.RandomFactory;
+import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/*
+ * @test
+ * @summary Verifies that the GZIPInputStream works as expected when the underlying
+ *          InputStream is a blocking stream
+ * @key randomness
+ * @library /test/lib
+ * @build jdk.test.lib.net.URIBuilder jdk.test.lib.RandomFactory
+ * @run junit GZIPOverBlockingStreams
+ */
+class GZIPOverBlockingStreams {
+
+    private static final Random random = RandomFactory.getRandom();
+    private static final String MEMBER_CONTENT_FORMAT = "Hello member %d, foo bar hello world\n";
+    private static final ExecutorService httpServerExecutor = Executors.newCachedThreadPool();
+
+    private static Server nonHttpServer;
+    private static HttpServer httpServer;
+
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        // create a socket based (non-HTTP) server
+        nonHttpServer = new Server();
+        nonHttpServer.start();
+        System.err.println("(non-HTTP) server started at " + nonHttpServer.getAddress());
+
+        // create a HTTP server
+        final InetAddress loopback = InetAddress.getLoopbackAddress();
+        final InetSocketAddress serverAddr = new InetSocketAddress(loopback, 0);
+        httpServer = HttpServer.create(serverAddr, 0);
+        httpServer.setExecutor(httpServerExecutor);
+        httpServer.createContext("/", new HttpReqHandler());
+        httpServer.start();
+        System.err.println("started HTTP server at " + httpServer.getAddress());
+
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        if (nonHttpServer != null) {
+            System.err.println("stopping server " + nonHttpServer.getAddress());
+            nonHttpServer.close();
+        }
+        if (httpServer != null) {
+            System.err.println("stopping HTTP server " + httpServer.getAddress());
+            httpServer.stop(0);
+        }
+        httpServerExecutor.shutdownNow();
+    }
+
+    static List<Integer> numGZIPMembers() {
+        return List.of(1,
+                13,
+                42,
+                random.nextInt(2, 101) // a reasonable number of members, not too many
+        );
+    }
+
+    static List<Arguments> socketStreamTestArgs() {
+        final List<Arguments> args = new ArrayList<>();
+        final List<Integer> numMembers = numGZIPMembers();
+        for (boolean shouldCloseSocket : new boolean[]{true, false}) {
+            for (int n : numMembers) {
+                args.add(Arguments.of(n, shouldCloseSocket));
+            }
+        }
+        return args;
+    }
+
+    /*
+     * Verifies that when the GZIPInputStream is used to read GZIP content
+     * over a socket stream, it does not block when reading past a member trailer to determine
+     * the presence of a subsequent member.
+     */
+    @ParameterizedTest
+    @MethodSource("socketStreamTestArgs")
+    void testSocketStream(final int numMembers, final boolean shouldCloseSocket) throws Exception {
+        final InetSocketAddress serverAddr = nonHttpServer.getAddress();
+        try (final Socket socket = new Socket(serverAddr.getAddress(), serverAddr.getPort())) {
+            System.err.println("connect established " + socket);
+            try (final OutputStream os = socket.getOutputStream();
+                 final DataOutputStream dos = new DataOutputStream(os)) {
+                // instruct the server side the number of GZIP members we want in the response
+                dos.writeInt(numMembers);
+                // instruct the server side whether to close the socket after writing out the
+                // response
+                dos.writeBoolean(shouldCloseSocket);
+                System.err.println("sent request for GZIP stream with " + numMembers + " members");
+                // read the response
+                try (final InputStream in = socket.getInputStream();
+                     final GZIPInputStream gzipInputStream = new GZIPInputStream(in)) {
+                    final byte[] decompressed = gzipInputStream.readAllBytes();
+                    System.err.println("read " + decompressed.length
+                            + " bytes of decompressed response");
+                    // verify it's the expected content
+                    assertDecompressedContent(numMembers, decompressed);
+                }
+            }
+        }
+        final Throwable serverFailure = nonHttpServer.failure;
+        if (serverFailure != null) {
+            fail("Server ran into an error", serverFailure);
+        }
+    }
+
+    static List<Arguments> httpTestArgs() {
+        final List<Arguments> args = new ArrayList<>();
+        final List<Integer> numMembers = numGZIPMembers();
+        for (boolean chunkedOrNot : new boolean[]{true, false}) {
+            for (int n : numMembers) {
+                args.add(Arguments.of(n, chunkedOrNot));
+            }
+        }
+        return args;
+    }
+
+    /*
+     * Verifies that when the GZIPInputStream is used to read GZIP content,
+     * over a stream obtained from a HTTP response, it does not block when reading past a member
+     * trailer to determine the presence of a subsequent member.
+     */
+    @ParameterizedTest
+    @MethodSource("httpTestArgs")
+    void testHttpStream(final int numMembers, final boolean httpResponseChunked) throws Exception {
+        final URI reqURI = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(httpServer.getAddress().getPort())
+                .path("/")
+                .build();
+        final HttpURLConnection conn = (HttpURLConnection) reqURI.toURL().openConnection();
+        conn.setRequestProperty("numMembers", String.valueOf(numMembers));
+        conn.setRequestProperty("chunkedResponse", String.valueOf(httpResponseChunked));
+        System.err.println("issuing request " + reqURI);
+        try (final InputStream in = conn.getInputStream();
+             final GZIPInputStream gzipInputStream = new GZIPInputStream(in)) {
+            final byte[] decompressed = gzipInputStream.readAllBytes();
+            System.err.println("read " + decompressed.length
+                    + " bytes of decompressed response");
+            assertDecompressedContent(numMembers, decompressed);
+        }
+    }
+
+    /*
+     * Creates and returns bytes representing a GZIP stream consisting of the given number of
+     * members.
+     */
+    private static byte[] createGZIPStream(final int numMembers) throws IOException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        for (int i = 1; i <= numMembers; i++) {
+            final ByteArrayOutputStream member = new ByteArrayOutputStream();
+            try (final OutputStream gzip = new GZIPOutputStream(member)) {
+                final String memberContent = String.format(MEMBER_CONTENT_FORMAT, i);
+                gzip.write(memberContent.getBytes(US_ASCII));
+            }
+            // write out the GZIP member to the stream which accumulates all the members
+            baos.write(member.toByteArray());
+        }
+        return baos.toByteArray();
+    }
+
+    /*
+     * Verifies that the given decompressed bytes, representing the given number of
+     * GZIP members, do match the expected content.
+     */
+    private static void assertDecompressedContent(final int numMembers,
+                                                  final byte[] decompressed) {
+        final String actual = new String(decompressed, US_ASCII);
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= numMembers; i++) {
+            sb.append(String.format(MEMBER_CONTENT_FORMAT, i));
+        }
+        final String expected = sb.toString();
+        assertEquals(expected, actual, "unexpected decompressed content");
+    }
+
+    /*
+     * A server which communicates over a socket to receive a request consisting of an integer
+     * representing the number of GZIP members to respond with. The server then responds back
+     * on the socket's OutputStream with GZIP content representing those many members.
+     */
+    private static final class Server implements AutoCloseable, Runnable {
+        private final ServerSocket serverSocket;
+        private volatile boolean stop;
+        private volatile Throwable failure;
+
+        private Server() throws IOException {
+            this.serverSocket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
+        }
+
+        private InetSocketAddress getAddress() {
+            return (InetSocketAddress) this.serverSocket.getLocalSocketAddress();
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.stop = true;
+            System.err.println("closing server: " + this.serverSocket);
+            this.serverSocket.close();
+        }
+
+        private void start() {
+            final Thread t = new Thread(this);
+            t.setName("server");
+            t.setDaemon(true);
+            t.start();
+        }
+
+        private synchronized void recordServerFailure(final Throwable t) {
+            Throwable previous = this.failure;
+            if (previous != null && previous != t) {
+                previous.addSuppressed(t);
+                return;
+            }
+            this.failure = t;
+        }
+
+        @Override
+        public void run() {
+            System.err.println("server started accepting requests at " + this.serverSocket);
+            try {
+                doRun();
+            } catch (Throwable t) {
+                if (!stop) { // ignore failures if the server is stopped
+                    recordServerFailure(t);
+                    System.err.println("server ran into error: " + t);
+                    t.printStackTrace();
+                }
+            } finally {
+                try {
+                    this.close();
+                } catch (IOException ioe) {
+                    System.err.println("ignoring excpetion " +
+                            "that happened during closing server: " + ioe);
+                    ioe.printStackTrace();
+                }
+            }
+        }
+
+        private void doRun() throws Exception {
+            while (!this.stop) {
+                // we intentionally do not close the Socket. It's upto the
+                // sendGZIPResponse(...) method to do that only if the test
+                // request has instructed it to do so. This allows the test
+                // method to exercise the case where the socket is open
+                // but doesn't have any more data to send (and thus read() blocks)
+                final Socket socket = this.serverSocket.accept();
+                System.err.println("accepted connection from " + socket);
+                // handle the request on a separate thread
+                final Thread handler = new Thread(() -> {
+                    try {
+                        handleRequest(socket);
+                    } catch (Throwable t) {
+                        // keep track of the failure
+                        recordServerFailure(t);
+                        System.err.println("failure when handling request on socket "
+                                + socket + ", exception: " + t);
+                        t.printStackTrace();
+                    }
+                });
+                handler.setName("request-handler-" + socket.getRemoteSocketAddress());
+                handler.setDaemon(true);
+                handler.start();
+            }
+        }
+
+        private static void handleRequest(final Socket socket) throws IOException {
+            final int numMembers;
+            final boolean shouldCloseSocket;
+            try {
+                final InputStream in = socket.getInputStream();
+                final DataInputStream dis = new DataInputStream(in);
+                // read the socket's inputstream to determine how many GZIP members are
+                // expected in the response stream, by the client
+                numMembers = dis.readInt();
+                // whether the socket should be closed after writing out the response
+                shouldCloseSocket = dis.readBoolean();
+            } catch (IOException ioe) {
+                // could be a socket connection from an unexpected client, so ignore any
+                // failure when reading the request
+                System.err.println("Ignoring exception that happened when reading" +
+                        " request from client socket " + socket + ", exception: " + ioe);
+                ioe.printStackTrace();
+                // close the unexpected client connection
+                socket.close();
+                return;
+            }
+            // valid request, respond to it with a GZIP response
+            sendGZIPResponse(socket, numMembers, shouldCloseSocket);
+        }
+
+        /*
+         * Sends GZIP content over the socket's OutputStream. This method closes the socket
+         * only if the test request (read over the socket's InputStream) instructs it to do so.
+         */
+        private static void sendGZIPResponse(final Socket socket, final int numMembers,
+                                             final boolean shouldCloseSocket) throws IOException {
+            // respond back with a GZIP output, containing the expected number of members
+            final byte[] gzipResponse = createGZIPStream(numMembers);
+            System.err.println("responding to " + socket + " with a GZIP stream of size "
+                    + gzipResponse.length + " with " + numMembers + " members");
+            final OutputStream os = socket.getOutputStream();
+            os.write(gzipResponse);
+            System.err.println("done responding to " + socket);
+            // close the socket only if the test request wants us to
+            if (shouldCloseSocket) {
+                System.err.println("closing " + socket);
+                socket.close();
+            }
+        }
+    }
+
+    /*
+     * A HTTP request handler which responds back with chunked or non-chunked
+     * response containing GZIP content.
+     */
+    private static final class HttpReqHandler implements HttpHandler {
+
+        @Override
+        public void handle(final HttpExchange exchange) throws IOException {
+            final URI reqURI = exchange.getRequestURI();
+            System.err.println("handling request: " + reqURI + " from "
+                    + exchange.getRemoteAddress());
+
+            final String val = exchange.getRequestHeaders().getFirst("numMembers");
+            final int numMembers = Integer.parseInt(val);
+            final boolean respChunked = Boolean.parseBoolean(
+                    exchange.getRequestHeaders().getFirst("chunkedResponse"));
+
+            final byte[] gzipResponse = createGZIPStream(numMembers);
+            System.err.println("responding to " + reqURI
+                    + " with a GZIP stream of size " + gzipResponse.length
+                    + " with " + numMembers + " members"
+                    + " with chunked response = " + respChunked);
+
+            // drain the inputstream and write out the response
+            exchange.getRequestBody().readAllBytes();
+            if (respChunked) {
+                exchange.sendResponseHeaders(200, 0); // 0 = Chunked response
+            } else {
+                exchange.sendResponseHeaders(200, gzipResponse.length);
+            }
+            try (final OutputStream os = exchange.getResponseBody()) {
+                os.write(gzipResponse);
+            }
+            System.err.println("done responding to " + reqURI);
+        }
+    }
+}

--- a/test/jdk/java/util/zip/GZIP/GZIPOverBlockingStreams.java
+++ b/test/jdk/java/util/zip/GZIP/GZIPOverBlockingStreams.java
@@ -27,6 +27,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -62,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @key randomness
  * @library /test/lib
  * @build jdk.test.lib.net.URIBuilder jdk.test.lib.RandomFactory
+ * @modules java.base/java.util.zip:open
  * @run junit GZIPOverBlockingStreams
  * @comment verify it behaves the same when jdk.util.gzip.tryReadAheadAfterTrailer system property
  *          is set to false
@@ -76,6 +78,21 @@ class GZIPOverBlockingStreams {
     private static Server nonHttpServer;
     private static HttpServer httpServer;
 
+    // 'GZIPInputStream.alwaysReadNextMember' configures whether GZIPInputStream skips the call to
+    // 'InputStream.available()' when checking for additional GZIP members in a stream. Tests which
+    // specifically test the non-blocking behavior (i.e. for the 'alwaysReadNextMember=false' case)
+    // have to be skipped if 'GZIPInputStream.alwaysReadNextMember' is 'true'.
+    static boolean alwaysReadNextMember = false;
+    static {
+        try {
+            Field alwaysReadNextMemberField = GZIPInputStream.class.getDeclaredField("alwaysReadNextMember");
+            alwaysReadNextMemberField.setAccessible(true);
+            alwaysReadNextMember = alwaysReadNextMemberField.getBoolean(null);
+        } catch (Exception e) {
+            System.out.println("Warning: can't get value of 'GZIPInputStream.alwaysReadNextMember'");
+            e.printStackTrace(System.out);
+        }
+    }
 
     @BeforeAll
     static void beforeAll() throws Exception {
@@ -119,7 +136,7 @@ class GZIPOverBlockingStreams {
     static List<Arguments> socketStreamTestArgs() {
         final List<Arguments> args = new ArrayList<>();
         final List<Integer> numMembers = numGZIPMembers();
-        for (boolean shouldCloseSocket : new boolean[]{true, false}) {
+        for (boolean shouldCloseSocket : new boolean[]{true, alwaysReadNextMember ? true : false}) {
             for (int n : numMembers) {
                 args.add(Arguments.of(n, shouldCloseSocket));
             }
@@ -166,7 +183,7 @@ class GZIPOverBlockingStreams {
     static List<Arguments> httpTestArgs() {
         final List<Arguments> args = new ArrayList<>();
         final List<Integer> numMembers = numGZIPMembers();
-        for (boolean chunkedOrNot : new boolean[]{true, false}) {
+        for (boolean chunkedOrNot : new boolean[]{alwaysReadNextMember ? false : true, false}) {
             for (int n : numMembers) {
                 args.add(Arguments.of(n, chunkedOrNot));
             }


### PR DESCRIPTION
This is a clean downport of:

- [8322256: Define and document GZIPInputStream concatenated stream semantics](https://bugs.openjdk.org/browse/JDK-8322256)
- [8385891: Introduce a test for GZIPInputStream whose underlying stream is a blocking InputStream](https://bugs.openjdk.org/browse/JDK-8385891)
- [8385924: GZIPInputStream.read() behaves differently on some Java versions](https://bugs.openjdk.org/browse/JDK-8385924)

From JDK 27 to Corretto 25. These downports don't currently change the behavior of `GZIPInputStream::read()` for multi-member gzip streams, but are a pre-requisit for restoring the original JDK 25 behavior of `GZIPInputStream::read()` to reliably read multi-member gzip streams.

Once these three commits have been downported, we will do another change, which sets the default value for `jdk.util.gzip.tryReadAheadAfterTrailer` from `false` to `true` and finally restores the original JDK 25 behavior (see #69 for more details). 

Tier 1 passes with the default settings `jdk.util.gzip.tryReadAheadAfterTrailer=false` (except native gTests because I didn't build gTest):
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
>> jtreg:test/hotspot/jtreg:tier1                     3057  2827     8     0   222 << (only gTest failures)
   jtreg:test/jdk:tier1                               2549  2507     0     0    42
   jtreg:test/langtools:tier1                         4655  4646     0     0     9
   jtreg:test/jaxp:tier1                                 0     0     0     0     0
   jtreg:test/lib-test:tier1                            37    37     0     0     0
==============================
```

When running with `JTREG="OPTIONS=-javaoption:-Djdk.util.gzip.tryReadAheadAfterTrailer=true"` (i.e. the new default after the net change), I get:
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
>> jtreg:test/hotspot/jtreg:tier1                     3057  2827     8     0   222 << (only gTest failures)
>> jtreg:test/jdk:tier1                               2549  2505     1     1    42 << (JDK-8387769)
   jtreg:test/langtools:tier1                         4655  4646     0     0     9
   jtreg:test/jaxp:tier1                                 0     0     0     0     0
   jtreg:test/lib-test:tier1                            37    37     0     0     0
==============================
```

I've opened [8387769: GZIPInputStream tests should succeed with tryReadAheadAfterTrailer true and false](https://bugs.openjdk.org/browse/JDK-8387769) for the two test failures. If we mange to quickly get the fix for [8387769](https://bugs.openjdk.org/browse/JDK-8387769) integrated, we can downport it as well. Otherwise we would have to exclude those two tests in Corretto 25 until the next release.