### PR TITLE
8343606: Test FinalizerTest.java intermittent fails Debuggee heap OOM

### DIFF
--- a/test/jdk/com/sun/jdi/FinalizerTest.java
+++ b/test/jdk/com/sun/jdi/FinalizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,15 +30,17 @@
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g FinalizerTest.java
  *
- * @run driver FinalizerTest
+ * @run driver FinalizerTest -Xmx256M
  */
-import com.sun.jdi.*;
-import com.sun.jdi.event.*;
-import com.sun.jdi.request.*;
-
-import java.util.List;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.sun.jdi.StackFrame;
+import com.sun.jdi.event.BreakpointEvent;
+import com.sun.jdi.event.StepEvent;
 
 
 /*
@@ -48,8 +50,7 @@ import java.util.Iterator;
  * @author Gordon Hirsch  (modified for HotSpot by tbell & rfield)
  */
 class FinalizerTarg {
-    static String lockit = "lock";
-    static boolean finalizerRun = false;
+    static final CountDownLatch finalizerDone = new CountDownLatch(1);
     static class BigObject {
         String name;
         byte[] foo = new byte[300000];
@@ -67,7 +68,7 @@ class FinalizerTarg {
              */
             super.finalize();
             //Thread.dumpStack();
-            finalizerRun = true;
+            finalizerDone.countDown();
         }
     }
 
@@ -77,29 +78,36 @@ class FinalizerTarg {
         b = null; // Drop the object, creating garbage...
         System.gc();
         System.runFinalization();
+        try {
+            // finalize() is run in another lower priority Finalizer thread.
+            // Wait for it to finish.
+            finalizerDone.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
 
-        // Now, we have to make sure the finalizer
-        // gets run.  We will keep allocating more
-        // and more memory with the idea that eventually,
-        // the memory occupied by the BigObject will get reclaimed
-        // and the finalizer will be run.
+        // If System.gc() and System.runFinalization() did not trigger the
+        // finalizer, then finalizerDone.await() will time out and the code
+        // below will be needed as a second attempt to trigger finalization.
         List holdAlot = new ArrayList();
         for (int chunk=10000000; chunk > 10000; chunk = chunk / 2) {
-            if (finalizerRun) {
+            if (finalizerDone.getCount() == 0) {
                 return;
             }
             try {
-                while(true) {
+                while (finalizerDone.getCount() > 0) {
                     holdAlot.add(new byte[chunk]);
                     System.err.println("Allocated " + chunk);
                 }
-            }
-            catch ( Throwable thrown ) {  // OutOfMemoryError
+            } catch ( Throwable thrown ) {  // OutOfMemoryError
+            } finally {
+                holdAlot.clear();
                 System.gc();
             }
             System.runFinalization();
         }
-        return;  // not reached
+        System.out.println("The Debuggee should not reach here in theory!");
+        return;
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Backport of JDK-8343606: Test FinalizerTest.java intermittent fails Debuggee heap OOM

This PR fixes intermittent OOM in FinalizerTest.java by using a CountDownLatch to wait for finalization instead of allocating memory until the heap is exhausted.

The backport is clean.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/com/sun/jdi/FinalizerTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29801940/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29801941/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29801943/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29801944/linux-aarch64-specific-test.log)
